### PR TITLE
fix P3608 - EU VAT number

### DIFF
--- a/wikidata-externalid-url/index.php
+++ b/wikidata-externalid-url/index.php
@@ -167,7 +167,7 @@ if (! empty($id) ) {
   case 3608: // EU VAT number
     $member_state_code = substr($id, 0, 2);
     $vat_digits = substr($id, 2);
-    $link_string = "$member_state_code&number=$vat_digits";
+    $link_string = "$member_state_code/vat/$vat_digits";
     break;
   case 3723: // USCG Lighthouse ID
     preg_match('/(\d+)-(\d+(?:.\d*)?)/', $id, $a);


### PR DESCRIPTION
new website requires country code and VAT ID separated differently

e.g. 
https://wikidata-externalid-url.toolforge.org/index.php?p=3608&url_prefix=https://ec.europa.eu/taxation_customs/vies/rest-api/ms/&id=HR38453148181


should produce https://ec.europa.eu/taxation_customs/vies/rest-api/ms/HR/vat/38453148181

