### PR TITLE
Add support for NexusMods mod ID (P13405)

### DIFF
--- a/wikidata-externalid-url/index.php
+++ b/wikidata-externalid-url/index.php
@@ -304,6 +304,12 @@ if (! empty($id) ) {
     $page = implode(':', $paradox_parts);
     $link_string = "https://$wiki.paradoxwikis.com/$page";
     break;
+  case 13405: // NexusMods mod ID
+    $nexusmods_parts = explode(":", $id);
+    $slug = array_shift($nexusmods_parts);
+    $numeric_id = implode(':', $nexusmods_parts);
+    $link_string = "https://www.nexusmods.com/$slug/mods/$numeric_id";
+    break;	 
   default:
     if (! empty($exp) ) {
       preg_match('/'.$exp.'/', $id, $a);
@@ -390,6 +396,7 @@ print "<li>ft.dk politician identifier - property 7882</li>";
 print "<li>VcBA ID - property 8034</li>";
 print "<li>Dictionary of Occupational Titles code - property 8679</li>";
 print "<li>wiki.gg article ID - property 11988</li>";
+print "<li>NexusMods mod ID - property 13405</li>";
 print "</ul>";
 
 print "The <a href=\"https://github.com/arthurpsmith/wikidata-tools/tree/master/wikidata-externalid-url\">source code for this service</a> is available under the <a href=\"http://www.apache.org/licenses/LICENSE-2.0\">Apache License, Version 2.0</a>." ;


### PR DESCRIPTION
Necessary support for proper URL redirection as per [discussion](https://www.wikidata.org/wiki/Wikidata:Property_proposal/NexusMods_mod_ID). For instance, `cyberpunk2077:5208` which resolves `https://www.nexusmods.com/cyberpunk2077/mods/5208`. I hope I have done this correctly, if not, please kindly correct me.